### PR TITLE
Add `every_page` option in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ mathjax:
   cjk_width: 0.9 # relative CJK char width
   normal_width: 0.6 # relative normal (monospace) width
   append_css: true # add CSS to every page
+  enable_every_page: false # if true, every page will be rendered by mathjax regardless the `mathjax` setting in Front-matter of each article
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ mathjax:
   cjk_width: 0.9 # relative CJK char width
   normal_width: 0.6 # relative normal (monospace) width
   append_css: true # add CSS to every page
-  enable_every_page: false # if true, every page will be rendered by mathjax regardless the `mathjax` setting in Front-matter of each article
+  every_page: false # if true, every page will be rendered by mathjax regardless the `mathjax` setting in Front-matter of each article
 ```
 
 ## Usage

--- a/index.js
+++ b/index.js
@@ -8,13 +8,13 @@ const config = hexo.config.mathjax = Object.assign({
   cjk_width     : 0.9,
   normal_width  : 0.6,
   append_css    : true,
-  enable_every_page :false
+  every_page    : false
 }, hexo.config.mathjax);
 
 const mathjax = require('./lib/filter')(config);
 
 hexo.extend.filter.register('after_post_render', data => {
-  if (!data.mathjax && !config.enable_every_page) return;
+  if (!data.mathjax && !config.every_page) return;
 
   data.content = mathjax(data.content);
   return data;

--- a/index.js
+++ b/index.js
@@ -7,13 +7,14 @@ const config = hexo.config.mathjax = Object.assign({
   single_dollars: true,
   cjk_width     : 0.9,
   normal_width  : 0.6,
-  append_css    : true
+  append_css    : true,
+  enable_every_page :false
 }, hexo.config.mathjax);
 
 const mathjax = require('./lib/filter')(config);
 
 hexo.extend.filter.register('after_post_render', data => {
-  if (!data.mathjax) return;
+  if (!data.mathjax && !config.enable_every_page) return;
 
   data.content = mathjax(data.content);
   return data;


### PR DESCRIPTION
When setting enable_every_page as true, all the articles will be rendered by mathjax regardless of the `mathjax` setting in the Front-matter of each article.
This will help those previously use other latex plugins and the people like me who will forget to add `mathjax: true` in the Front-matter of articles.