### PR TITLE
fix a bug that css will be added repeatedly

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,9 @@ if (config.append_css) {
   const css = require('./lib/css');
 
   hexo.extend.filter.register('after_render:html', data => {
-    return data.replace(/<head>(?!<\/head>).+?<\/head>/s, str => str.replace('</head>', `<style>${css}</style></head>`));
+    // add unique token to prevent replacing repeatedly
+    if (data.match(`<meta name="hexo-filter-mathjax-css" content="placeholder">`)) return;
+    return data.replace(/<head>(?!<\/head>).+?<\/head>/s, str => str.replace('</head>',
+          `<meta name="hexo-filter-mathjax-css" content="placeholder"> <style>${css}</style></head>`));
   });
 }


### PR DESCRIPTION
There is a bug that the inline css will be added repeatedly due to the similar behavior to "hexo-generator-feed".

The bug is show as below.
![duplicate_css](https://user-images.githubusercontent.com/31380016/87677961-efd16000-c7ac-11ea-861c-7ae0d2e867b4.png)

Solution:
Add an unique token (html tag) to show that the inline css has been added.